### PR TITLE
Patches for routines, buttons and custom URLs

### DIFF
--- a/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
+++ b/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
@@ -1610,20 +1610,22 @@ private Boolean executeTask(rtData, devices, statement, task, async) {
 		params.push p
     }
 
- 	def vcmd = rtData.commands.virtual[task.c]
+	def command = task.c == "pushMomentary" ? "push" : task.c	
+
+ 	def vcmd = rtData.commands.virtual[command]
     long delay = 0
     for (device in (virtualDevice ? [virtualDevice] : devices)) {
-        if (!virtualDevice && device.hasCommand(task.c)) {
-            def msg = timer "Executed [$device].${task.c}"
+        if (!virtualDevice && device.hasCommand(command)) {
+            def msg = timer "Executed [$device].${command}"
         	try {
-            	delay = "cmd_${task.c}"(rtData, device, params)
+            	delay = "cmd_${command}"(rtData, device, params)
             } catch(all) {
-	            executePhysicalCommand(rtData, device, task.c, params)
+	            executePhysicalCommand(rtData, device, command, params)
 			}
             if (rtData.logging > 1) trace msg, rtData
         } else {
             if (vcmd) {
-	        	delay = executeVirtualCommand(rtData, vcmd.a ? devices : device, task, params)
+	        	delay = executeVirtualCommand(rtData, vcmd.a ? devices : device, command, params)
                 //aggregate commands only run once, for all devices at the same time
                 if (vcmd.a) break
             }
@@ -1652,15 +1654,15 @@ private Boolean executeTask(rtData, devices, statement, task, async) {
     return true
 }
 
-private long executeVirtualCommand(rtData, devices, task, params)
+private long executeVirtualCommand(rtData, devices, command, params)
 {
-	def msg = timer "Executed virtual command ${devices ? (devices instanceof List ? "$devices." : "[$devices].") : ""}${task.c}"
+	def msg = timer "Executed virtual command ${devices ? (devices instanceof List ? "$devices." : "[$devices].") : ""}${command}"
     long delay = 0
     try {
-		delay = "vcmd_${task.c}"(rtData, devices, params)
+		delay = "vcmd_${command}"(rtData, devices, params)
 	    if (rtData.logging > 1) trace msg, rtData
     } catch(all) {
-    	msg.m = "Error executing virtual command ${devices instanceof List ? "$devices" : "[$devices]"}.${task.c}:"
+    	msg.m = "Error executing virtual command ${devices instanceof List ? "$devices" : "[$devices]"}.${command}:"
         msg.e = all
         error msg, rtData
     }

--- a/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
+++ b/smartapps/ady624/webcore-piston.src/webcore-piston.groovy
@@ -4284,13 +4284,14 @@ private traverseExpressions(node, closure, param, parentNode = null) {
 }
 
 private getRoutineById(routineId) {
-	def routines = location.helloHome?.getPhrases()
+    return [ id : routineId ]
+	/*def routines = location.helloHome?.getPhrases()
     for(routine in routines) {
     	if (routine && routine?.label && (hashId(routine.id) == routineId)) {
     		return routine
         }
     }
-    return null
+    return null */
 }
 
 private void updateDeviceList(deviceIdList) {
@@ -4397,7 +4398,7 @@ private void subscribeAll(rtData) {
                             	def routine = getRoutineById(value.c)
                                 if (routine) {
 	                        		subscriptionId = "$deviceId${operand.v}${routine.id}"
-    	                        	attribute = "routineExecuted.${routine.id}"
+    	                        	attribute = "routineExecuted"
                                 }
                             }
                             break

--- a/smartapps/ady624/webcore-storage.src/webcore-storage.groovy
+++ b/smartapps/ady624/webcore-storage.src/webcore-storage.groovy
@@ -161,8 +161,15 @@ def Map listAvailableDevices(raw = false) {
 	if (raw) {
     	return settings.findAll{ it.key.startsWith("dev:") }.collect{ it.value }.flatten().collectEntries{ dev -> [(hashId(dev.id)): dev]}
     } else {
-    	return settings.findAll{ it.key.startsWith("dev:") }.collect{ it.value }.flatten().collectEntries{ dev -> [(hashId(dev.id)): dev]}.collectEntries{ id, dev -> [ (id): [ n: dev.getDisplayName(), cn: dev.getCapabilities()*.name, a: dev.getSupportedAttributes().unique{ it.name }.collect{def x = [n: it.name, t: it.getDataType(), o: it.getValues()]; try {x.v = dev.currentValue(x.n);} catch(all) {}; x}, c: dev.getSupportedCommands().unique{ it.getName() }.collect{[n: it.getName(), p: it.getArguments()]} ]]}
+    	return settings.findAll{ it.key.startsWith("dev:") }.collect{ it.value }.flatten().collectEntries{ dev -> [(hashId(dev.id)): dev]}.collectEntries{ id, dev -> [ (id): [ n: dev.getDisplayName(), cn: dev.getCapabilities()*.name, a: dev.getSupportedAttributes().unique{ it.name }.collect{def x = [n: it.name, t: it.getDataType(), o: it.getValues()]; try {x.v = dev.currentValue(x.n);} catch(all) {}; x}, c: dev.getSupportedCommands().unique{ transformCommand(it) }.collect{[n: transformCommand(it), p: it.getArguments()]} ]]}
 	}
+}
+
+private def transformCommand(command){
+    if(command.getName() == "push" && (command.getArguments()?.size() ?: 0) == 0){
+     	return "pushMomentary"   
+    }
+    return command.getName()
 }
 
 def Map getDashboardData() {

--- a/smartapps/ady624/webcore.src/webcore.groovy
+++ b/smartapps/ady624/webcore.src/webcore.groovy
@@ -1543,7 +1543,7 @@ private api_intf_dashboard_piston_activity() {
 
 def api_ifttt() {
 	def data = [:]
-    def remoteAddr = request.getHeader("X-FORWARDED-FOR") ?: request.getRemoteAddr()
+    def remoteAddr = "UNKNOWN" /*request.getHeader("X-FORWARDED-FOR") ?: request.getRemoteAddr() */
     if (params) {
     	data.params = [:]
         for(param in params) {
@@ -1575,7 +1575,8 @@ def api_email() {
 private api_execute() {
 	def result = [:]
 	def data = [:]
-    def remoteAddr = request.getHeader("X-FORWARDED-FOR") ?: request.getRemoteAddr()
+    log.debug request
+    def remoteAddr = "UNKOWN" /*request.getHeader("X-FORWARDED-FOR") ?: request.getRemoteAddr()*/
     debug "Dashboard: Request received to execute a piston from IP $remoteAddr"
 	if (params) {
     	data = [:]
@@ -2384,8 +2385,7 @@ private static Map capabilities() {
 		audioNotification			: [ n: "Audio Notification",			d: "audio notification devices",											c: ["playText", "playTextAndResume", "playTextAndRestore", "playTrack", "playTrackAndResume", "playTrackAndRestore"],				 																],
 		battery						: [ n: "Battery",						d: "battery powered devices",		a: "battery",																																																								],
 		beacon						: [ n: "Beacon",						d: "beacons",						a: "presence",																																																								],
-		bulb						: [ n: "Bulb",							d: "bulbs",							a: "switch",							c: ["off", "on"],																																													],
-		button						: [ n: "Button",						d: "buttons",						a: "button",				m: true,	s: "numberOfButtons,numButtons", i: "buttonNumber",																																					],
+		bulb						: [ n: "Bulb",							d: "bulbs",							a: "switch",							c: ["off", "on"],																																													],		
 		carbonDioxideMeasurement	: [ n: "Carbon Dioxide Measurement",	d: "carbon dioxide sensors",		a: "carbonDioxide",																																																							],
 		carbonMonoxideDetector		: [ n: "Carbon Monoxide Detector",		d: "carbon monoxide detectors",		a: "carbonMonoxide",																																																						],
 		colorControl				: [ n: "Color Control",					d: "adjustable color lights",		a: "color",								c: ["setColor", "setHue", "setSaturation"],																																							],
@@ -2394,10 +2394,11 @@ private static Map capabilities() {
 		consumable					: [ n: "Consumable",					d: "consumables",					a: "consumableStatus",					c: ["setConsumableStatus"],																																											],
 		contactSensor				: [ n: "Contact Sensor",				d: "contact sensors",				a: "contact",																																																								],
 		doorControl					: [ n: "Door Control",					d: "automatic doors",				a: "door",								c: ["close", "open"],																																												],
+        doubleTapableButton			: [ n: "Double Tapable Button",			d: "double tapable buttons",		a: "doubleTapped",						c: ["doubleTap"],																																													],
 		energyMeter					: [ n: "Energy Meter",					d: "energy meters",					a: "energy",																																																								],
 		estimatedTimeOfArrival		: [ n: "Estimated Time of Arrival", 	d: "moving devices (ETA)",			a: "eta",																																																									],
 		garageDoorControl			: [ n: "Garage Door Control",			d: "automatic garage doors",		a: "door",								c: ["close", "open"],																																												],
-		holdableButton				: [ n: "Holdable Button",				d: "holdable buttons",				a: "button",				m: true,	s: "numberOfButtons,numButtons", i: "buttonNumber",																																					],
+		holdableButton				: [ n: "Holdable Button",				d: "holdable buttons",				a: "held",								c: ["hold"]																																															],        
 		illuminanceMeasurement		: [ n: "Illuminance Measurement",		d: "illuminance sensors",			a: "illuminance",																																																							],
 		imageCapture				: [ n: "Image Capture",					d: "cameras, imaging devices",		a: "image",								c: ["take"],																																														],
 		indicator					: [ n: "Indicator",						d: "indicator devices",				a: "indicatorStatus",					c: ["indicatorNever", "indicatorWhenOn", "indicatorWhenOff"],																																		],
@@ -2416,6 +2417,7 @@ private static Map capabilities() {
 		powerMeter					: [ n: "Power Meter",					d: "power meters",					a: "power",																																																									],
 		powerSource					: [ n: "Power Source",					d: "multisource powered devices",	a: "powerSource",																																																							],
 		presenceSensor				: [ n: "Presence Sensor",				d: "presence sensors",				a: "presence",																																																								],
+        pushableButton				: [ n: "Pushable Button",				d: "pushable buttons",				a: "pushed",							c: ["push"],																																														],
 		refresh						: [ n: "Refresh",						d: "refreshable devices",													c: ["refresh"],																																														],
 		relativeHumidityMeasurement	: [ n: "Relative Humidity Measurement",	d: "humidity sensors",				a: "humidity",																																																								],
 		relaySwitch					: [ n: "Relay Switch",					d: "relay switches",				a: "switch",							c: ["off", "on"],																																													],
@@ -2460,8 +2462,7 @@ private static Map attributes() {
 		axisX						: [ n: "X axis",				t: "integer",	r: [-1024, 1024],	s: "threeAxis",																	],
 		axisY						: [ n: "Y axis",				t: "integer",	r: [-1024, 1024],	s: "threeAxis",																	],
 		axisZ						: [ n: "Z axis",				t: "integer",	r: [-1024, 1024],	s: "threeAxis",																	],
-		battery						: [ n: "battery", 				t: "integer",	r: [0, 100],		u: "%",																			],
-		button						: [ n: "button", 				t: "enum",		o: ["pushed", "held"],									c: "button",					m: true, s: "numberOfButtons,numButtons", i: "buttonNumber"		],
+		battery						: [ n: "battery", 				t: "integer",	r: [0, 100],		u: "%",																			],		
 		carbonDioxide				: [ n: "carbon dioxide",		t: "decimal",	r: [0, null],																						],
 		carbonMonoxide				: [ n: "carbon monoxide",		t: "enum",		o: ["clear", "detected", "tested"],																	],
 		color						: [ n: "color",					t: "color",																											],
@@ -2471,12 +2472,13 @@ private static Map attributes() {
 		coolingSetpoint				: [ n: "cooling setpoint",		t: "decimal",	r: [-127, 127],		u: '°?',															],
 		currentActivity				: [ n: "current activity",		t: "string",																										],
 		door						: [ n: "door",					t: "enum",		o: ["closed", "closing", "open", "opening", "unknown"],					p: true,					],
+        doubleTapped				: [ n: "double tapped button", 	t: "integer",	c: "doubleTapableButton"																			],
 		energy						: [ n: "energy",				t: "decimal",	r: [0, null],		u: "kWh",																		],
 		eta							: [ n: "ETA",					t: "datetime",																										],
 		goal						: [ n: "goal",					t: "integer",	r: [0, null],																						],
 		heatingSetpoint				: [ n: "heating setpoint",		t: "decimal",	r: [-127, 127],		u: '°?',															],
-		hex							: [ n: "hexadecimal code",		t: "hexcolor",																										],
-		holdableButton				: [ n: "holdable button",		t: "enum",		o: ["held", "pushed"],								c: "holdableButton",			m: true,		],
+        held						: [ n: "held button", 			t: "integer",	c: "holdableButton"																					],
+		hex							: [ n: "hexadecimal code",		t: "hexcolor",																										],		
 		hue							: [ n: "hue",					t: "integer",	r: [0, 360],		u: "°",																			],
 		humidity					: [ n: "relative humidity",		t: "integer",	r: [0, 100],		u: "%",																			],
 		illuminance					: [ n: "illuminance",			t: "integer",	r: [0, null],		u: "lux",																		],
@@ -2497,6 +2499,7 @@ private static Map attributes() {
 		power						: [ n: "power",					t: "decimal",		u: "W",																			],
 		powerSource					: [ n: "power source",			t: "enum",		o: ["battery", "dc", "mains", "unknown"],															],
 		presence					: [ n: "presence",				t: "enum",		o: ["not present", "present"],																		],
+        pushed						: [ n: "pushed button", 		t: "integer",	c: "pushableButton"																					],
 		rssi						: [ n: "signal strength",		t: "integer",	r: [0, 100],		u: "%",																			],
 		saturation					: [ n: "saturation",			t: "integer",	r: [0, 100],		u: "%",																			],
 		schedule					: [ n: "schedule",				t: "object",																										],
@@ -2561,6 +2564,7 @@ private static Map commands() {
 		configure					: [ n: "Configure",						i: 'gear',																																																										],
 		cool						: [ n: "Set to Cool",					i: 'asterisk',									a: "thermostatMode",				v: "cool",																																			],
 		deviceNotification			: [ n: "Send device notification...",	d: "Send device notification \"{0}\"",																		p: [[n:"Message",t:"string"]],  																							],
+        doubleTap					: [ n: "Double Tap",					d: "Double tap button {0}",						a: "doubleTapped",										p:[[n: "Button #", t: "integer"]]																																																										],
 		emergencyHeat				: [ n: "Set to Emergency Heat",															a: "thermostatMode",				v: "emergency heat",																																	],
 		fanAuto						: [ n: "Set fan to Auto",																a: "thermostatFanMode",				v: "auto",																																			],
 		fanCirculate				: [ n: "Set fan to Circulate",															a: "thermostatFanMode",				v: "circulate",																																		],
@@ -2568,6 +2572,7 @@ private static Map commands() {
 		getAllActivities			: [ n: "Get all activities",																																																													],
 		getCurrentActivity			: [ n: "Get current activity",																																																													],
 		heat						: [ n: "Set to Heat",					i: 'fire',										a: "thermostatMode",				v: "heat",																																			],
+        hold						: [ n: "Hold",							d: "Hold Button {0}",							a: "held",													p: [[n:"Button #", t: "integer"]]																																						],
 		indicatorNever				: [ n: "Disable indicator",																																																														],
 		indicatorWhenOff			: [ n: "Enable indicator when off",																																																												],
 		indicatorWhenOn				: [ n: "Enable indicator when on",																																																												],
@@ -2588,7 +2593,7 @@ private static Map commands() {
 		poll						: [ n: "Poll",						i: 'question',																																																											],
 		presetPosition				: [ n: "Move to preset position",														a: "windowShade",					v: "partially open",																																],
 		previousTrack				: [ n: "Previous track",																																																														],
-		push						: [ n: "Push",																																																																	],
+        push						: [ n: "Push",							d: "Push button {0}",							a: "pushed",												p:[[n: "Button #", t: "integer"]]																																																										],
 		refresh						: [ n: "Refresh",					i: 'refresh',																																																											],
 		restoreTrack				: [ n: "Restore track...",				d: "Restore track <uri>{0}</uri>",																			p: [[n:"Track URL",t:"url"]],  																								],
 		resumeTrack					: [ n: "Resume track...",				d: "Resume track <uri>{0}</uri>",																			p: [[n:"Track URL",t:"url"]],  																								],


### PR DESCRIPTION
Support subscriptions to routine events such as below. Must compare to the md5hash of "core.{routineId}" in between two ":" in the statement dialog which can be seen in the logs.

```
sendLocationEvent(name: 'routineExecuted', value: "{RoutineId}", isStateChange: true, displayed: true, 
                              linkText: "{RoutineName}", descriptionText: "{RoutineName} was executed")
```

Fix unsupported call to getHeader on request.

Add support for hubitat button implementation. Example bin code with virtual button device "ymjv". 
You might have to clear cache to test (I had to open the dashboard in incognito mode for the new commands to not show as "custom"). Maybe a version change in the app does this automatically but unsure on that.

Note that you if you send the same button twice it isn't seen as a "change" in webcore since the last attribute value will be the same as the new. Unsure if this should be changed in webcore or if the device should reset the value when the button stops being pressed. The virtual device  in hubitat does not change it back after pressing.