### PR TITLE
Fix for virtual flash, and looser restrictions on timing

### DIFF
--- a/smartapps/ady624/webcore-dashboard.src/webcore-dashboard.groovy
+++ b/smartapps/ady624/webcore-dashboard.src/webcore-dashboard.groovy
@@ -155,9 +155,7 @@ private void broadcastEvent(deviceId, eventName, eventValue, eventTime) {
             headers: ['ST' : state.instanceId],
             body: [d: deviceId, n: eventName, v: eventValue, t: eventTime]
         ]
-        
-    log.trace(params)
-
+    
     httpPut(params){
         resp ->resp.data
         log.info("broadcastEvent response :: ${resp.data}") 


### PR DESCRIPTION
Will need a logout/login for the flash command changes. 

Upped the schedule loop from 5 seconds to 20 seconds and the schedule search from 2 seconds to 3 to keep the flash commands within the same loop since the emulated ones need to run in this loop now instead of in the command([delay:delay]) device method which isn't supported in hubitat.

Also removed the hardcoded pushMomentary check to a more generic one.