### PR TITLE
Fix dashboard js error

### DIFF
--- a/dashboard/js/modules/dashboard.module.js
+++ b/dashboard/js/modules/dashboard.module.js
@@ -34,7 +34,7 @@ config.controller('dashboard', ['$scope', '$rootScope', 'dataService', '$timeout
 				if ($scope.$$destroyed) return;
 				if (currentRequestId != $scope.requestId) { return };
 				if (data) {
-					$scope.endpoint=data.endpoint + 'execute/:pistonId:' + '?access_token=' + si.accessToken;
+					$scope.endpoint=data.endpoint + 'execute/:pistonId:' + '?access_token=' + data.accessToken;
 					$scope.rawEndpoint=data.endpoint;
 					$scope.rawAccessToken=data.accessToken;
 					if (data.error) {


### PR DESCRIPTION
"si" is only defined after visiting the dashboard at least once. This prevents new logins from working. Use the access token from data.